### PR TITLE
fix behavior when tqdm missing

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -19,7 +19,7 @@ try:
     from tqdm import tqdm
 except ImportError:
     def tqdm(*args, **kwargs):
-        return args
+        return args[0]
 
 
 class IdentityMetric(object):


### PR DESCRIPTION
I noticed some confusing behavior when trying to run the NUTS sampler in an environment that does not have `tqdm`. Because the "fallback" `tqdm` function was passing through the `args` instead of just the *first* arg, the sampler was stopping early (basically the same as just executing 1 iteration/mc step, I think).  This 3-character change seems to fix it.